### PR TITLE
Adding support for importing files into frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ is a function that accepts the frontmatter data as a string, and returns the par
 `yaml` nodes will be parsed using [`yaml`](https://github.com/eemeli/yaml) and `toml` nodes using
 [`toml`](https://github.com/BinaryMuse/toml-node).
 
+### `keysToMapToImports`
+
+Sometimes it's very useful to map some keys to imports (specifically, things like assets). This allows frontmatter to import assets and include those.
+
 ### License
 
 [MIT](LICENSE.md) @ [Remco Haszing](https://github.com/remcohaszing)

--- a/__fixtures__/feature-image/expected.jsx
+++ b/__fixtures__/feature-image/expected.jsx
@@ -1,0 +1,11 @@
+/*@jsxRuntime automatic @jsxImportSource react*/
+export {default as featureImage} from "../../some-image.png";
+export const title = "Hello frontmatter", index = 1;
+function _createMdxContent(props) {
+  return <></>;
+}
+function MDXContent(props = {}) {
+  const {wrapper: MDXLayout} = props.components || ({});
+  return MDXLayout ? <MDXLayout {...props}><_createMdxContent {...props} /></MDXLayout> : _createMdxContent(props);
+}
+export default MDXContent;

--- a/__fixtures__/feature-image/input.md
+++ b/__fixtures__/feature-image/input.md
@@ -1,0 +1,5 @@
+---
+title: Hello frontmatter
+index: 1
+featureImage: ../../some-image.png
+---

--- a/__fixtures__/feature-image/options.json
+++ b/__fixtures__/feature-image/options.json
@@ -1,0 +1,3 @@
+{
+  "importSpecifiers": [{ "key": "featureImage" }]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,9 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
In order to reproduce the behaviour in Gatsby (https://www.gatsbyjs.com/plugins/@matiasfha/gatsby-plugin-frontmatter-featured-image/) we should be able to support extracting assets (or any other import) from frontmatter.

This new option provides this functionality. The options now allow us to specify which keys should be extracted as imports. I've left a little room for this to expand if additional naming adjustments need to be made (renaming, transforming, etc).

Using a combination of this and `mdx-bundler`, we can safely import all images with local paths and not worry about broken image paths:

```tsx
const { code, frontmatter } = await bundleMDX({
  source: fileContents,
  cwd: dirname(fullPath),
  mdxOptions(options) {
      options.remarkPlugins = [
          ...(options.remarkPlugins || []),
          remarkHeadingIdPlugin,
          remarkMdxImagesPlugin,
      ];
      options.remarkPlugins = options.remarkPlugins.map((plugin) => {
          if (Array.isArray(plugin) && plugin[1].name === "frontmatter") {
              return [remarkMdxFrontMatterPlugin, {
                  name: "frontmatter",
                  importSpecifiers: [{ key: "featureImage" }],
              }];
          }
          return plugin;
      });
      return options;
  },
  esbuildOptions(options) {
      // Extract images to public directory
      options.outdir = imagesDirectory;
      options.loader = {
          ...options.loader,
          ".png": "file",
      };
      options.publicPath = `/${imagesPublicPath}/`;
      options.write = true;

      return options;
  },
});

const { featureImage } = getMDXExport<{ featureImage?: string }, unknown>(code);
```

With this plugin modification, the code built up now has the proper extracted path to image. We could also make it so front-matter could point at layout components or anything else outside of the scope of the file.