### PR TITLE
Update README.md to ensure appropriate compilation output is logged

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ import { compile } from '@mdx-js/mdx'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
 
-const { contents } = await compile(await readFile('example.mdx'), {
+const { value } = await compile(await readFile('example.mdx'), {
   jsx: true,
   remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter]
 })
-console.log(contents)
+console.log(value)
 ```
 
 Roughly yields:


### PR DESCRIPTION
The `contents` was renamed to `value` in vfile, update the example in the readme to reflect the same.

Closes #15 